### PR TITLE
Add language relation to Course model

### DIFF
--- a/app/App/Course/Controllers/CourseController.php
+++ b/app/App/Course/Controllers/CourseController.php
@@ -39,6 +39,7 @@ final class CourseController extends Controller
                 'authors',
                 'tags',
                 'students',
+                'language',
             ])
             ->get();
 
@@ -82,6 +83,7 @@ final class CourseController extends Controller
                 'units.sections',
                 'authors',
                 'tags',
+                'language',
             ])
             ->where('id', $id)
             ->first();

--- a/app/App/Course/Resources/Course.php
+++ b/app/App/Course/Resources/Course.php
@@ -27,7 +27,6 @@ class Course extends JsonResource
             'learning_points'        => $this->getTranslations('learning_points'),
             // 'target_audience'        => $this->target_audience,
             // 'level'                  => $this->level,
-            'language'               => $this->language,
             'estimated_duration'     => $this->estimated_duration,
             'unique_views_count'     => $this->getUniqueViewsCount(),
             'published_at'           => $this->published_at,
@@ -36,6 +35,7 @@ class Course extends JsonResource
             'tags'                   => $this->whenLoaded('tags'),
             'units'                  => $this->whenLoaded('units'),
             'students'               => $this->whenLoaded('students'),
+            'language'               => $this->whenLoaded('language'),
             'created_at'             => $this->created_at,
             'updated_at'             => $this->updated_at,
         ];

--- a/app/Domain/Course/Models/Course.php
+++ b/app/Domain/Course/Models/Course.php
@@ -8,6 +8,7 @@ use CyrildeWit\EloquentViewable\Support\Period;
 use Domain\Model;
 use Domain\Topic\Models\Topic;
 use Domain\User\Models\User;
+use Domain\Language\Models\Language;
 use Illuminate\Database\Eloquent\Relations\BelongsToMany;
 use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
@@ -54,6 +55,11 @@ class Course extends Model implements Viewable
     {
         return $this->belongsToMany(User::class, 'course_enrolled', 'course_id', 'user_id')
             ->withTimestamps();
+    }
+
+    public function language(): BelongsTo
+    {
+        return $this->belongsTo(Language::class);
     }
 
     public function getUniqueViewsCount()

--- a/app/Domain/Language/Models/Language.php
+++ b/app/Domain/Language/Models/Language.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Domain\Language\Models;
+
+use Domain\Model;
+use Spatie\Translatable\HasTranslations;
+
+class Language extends Model
+{
+    use HasTranslations;
+
+    protected $table = 'languages';
+
+    public $translatable = [
+        'display_name',
+    ];
+}

--- a/database/migrations/2020_03_04_100000_create_languages_table.php
+++ b/database/migrations/2020_03_04_100000_create_languages_table.php
@@ -1,0 +1,20 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class CreateLanguagesTable extends Migration
+{
+    public function up()
+    {
+        Schema::create('languages', function (Blueprint $table) {
+            $table->id();
+            $table->json('display_name');
+            $table->string('locale')->unique();
+            $table->string('script');
+            $table->string('regional')->nullable();
+            $table->timestamps();
+        });
+    }
+}

--- a/database/migrations/2020_06_01_100000_create_courses_table.php
+++ b/database/migrations/2020_06_01_100000_create_courses_table.php
@@ -24,11 +24,12 @@ class CreateCoursesTable extends Migration
             // $table->json('target_audience')->nullable();
 
             // Meta
-            $table->string('language')->nullable();
             // $table->string('level')->nullable();
             // $table->string('status')->nullable()->default('draft');
             $table->integer('estimated_duration')->nullable();
             $table->date('published_at')->nullable();
+
+            $table->integer('language_id')->unsigned()->nullable();
 
             $table->bigInteger('unique_views_count')->default(0);
 

--- a/database/seeds/CoursesTableSeeder.php
+++ b/database/seeds/CoursesTableSeeder.php
@@ -3,6 +3,7 @@
 use Domain\Course\Models\Unit;
 use Domain\Course\Models\Course;
 use Domain\Course\Models\Section;
+use Domain\Language\Models\Language;
 use Domain\Topic\Models\Topic;
 use Illuminate\Database\Seeder;
 use Spatie\Tags\Tag;
@@ -38,7 +39,6 @@ class CoursesTableSeeder extends Seeder
         //     'Beginners',
         //     'Hobbiesten',
         // ];
-        $course->language = 'nl';
         // $course->level = 'gevorderde';
         $course->estimated_duration = 12;
         // $course->status = 'draft';
@@ -49,6 +49,9 @@ class CoursesTableSeeder extends Seeder
         $course->published_at = now();
         $course->created_at = now();
         $course->updated_at = now()->addWeeks(1);
+
+        // Language
+        $course->language()->associate(Language::where('locale', 'nl')->first());
 
         // Topic
         $course->topic()->associate(5);
@@ -144,7 +147,7 @@ class CoursesTableSeeder extends Seeder
         //     'Beginners',
         //     'Hobbiesten',
         // ];
-        $course->language = 'nl';
+        // $course->language = 'nl';
         // $course->level = 'beginner';
         $course->estimated_duration = 6;
         // $course->status = 'publish';
@@ -155,6 +158,9 @@ class CoursesTableSeeder extends Seeder
         $course->published_at = now();
         $course->created_at = now()->subWeeks(2);
         $course->updated_at = now()->subWeeks(2)->addWeeks(1);
+
+        // Language
+        $course->language()->associate(Language::where('locale', 'nl')->first());
 
         // Topic
         $course->topic()->associate(5);

--- a/database/seeds/DatabaseSeeder.php
+++ b/database/seeds/DatabaseSeeder.php
@@ -11,6 +11,7 @@ class DatabaseSeeder extends Seeder
      */
     public function run()
     {
+        $this->call(LanguagesTableSeeder::class);
         $this->call(UsersTableSeeder::class);
         $this->call(TagsTableSeeder::class);
         $this->call(TopicsTableSeeder::class);

--- a/database/seeds/LanguagesTableSeeder.php
+++ b/database/seeds/LanguagesTableSeeder.php
@@ -1,0 +1,25 @@
+<?php
+
+use Illuminate\Database\Seeder;
+use Domain\Language\Models\Language;
+
+class LanguagesTableSeeder extends Seeder
+{
+    /**
+     * Run the database seeds.
+     *
+     * @return void
+     */
+    public function run()
+    {
+        Language::create([
+            'locale' => 'nl',
+            'display_name' => [
+                'en' => 'Dutch',
+                'nl' => 'Nederlands',
+            ],
+            'script' => 'Latn',
+            'regional' => 'nl_NL'
+        ]);
+    }
+}


### PR DESCRIPTION
A course entity can only be localized in one language. This data should be stored in a belongs to a relationship.

A <course> belongs to a <language>.